### PR TITLE
feat: add public function to support encoding params for custom LP module

### DIFF
--- a/packages/doppler-v4-sdk/src/entities/factory/ReadWriteFactory.ts
+++ b/packages/doppler-v4-sdk/src/entities/factory/ReadWriteFactory.ts
@@ -160,6 +160,28 @@ export class ReadWriteFactory extends ReadFactory {
     );
   }
 
+  public encodeCustomLPLiquidityMigratorData(
+    customLPConfig: {
+      customLPWad: bigint;
+      customLPRecipient: Address;
+      lockupPeriod: number;
+    }
+  ): Hex {
+    return encodeAbiParameters(
+      [
+        { type: 'uint64' },
+        { type: 'address' },
+        { type: 'uint32' },
+
+      ],
+      [
+        customLPConfig.customLPWad,
+        customLPConfig.customLPRecipient,
+        customLPConfig.lockupPeriod,
+      ]
+    );
+  }
+
   public buildConfig(
     params: DopplerPreDeploymentConfig,
     addresses: DopplerV4Addresses
@@ -245,7 +267,7 @@ export class ReadWriteFactory extends ReadFactory {
         tokenFactory,
         tokenFactoryData: tokenParams,
         poolInitializer: v4Initializer,
-        poolInitializerData: dopplerParams,
+        poolInitializerData: dopplerParams
       });
 
     const governanceFactoryData = encodeAbiParameters(


### PR DESCRIPTION
This PR is to add a helper function to the v4 SDK for the usage of the [custom LP module](https://github.com/whetstoneresearch/doppler/pull/362) I added previously to Doppler contracts - I am just adding a single public function instead of including those params in the [`DopplerPreDeploymentConfig`](https://github.com/whetstoneresearch/doppler-sdk/blob/main/packages/doppler-v4-sdk/src/entities/factory/ReadWriteFactory.ts#L164) in [`buildConfig`](https://github.com/whetstoneresearch/doppler-sdk/blob/main/packages/doppler-v4-sdk/src/entities/factory/ReadWriteFactory.ts#L163) due to 1) simplicity and 2) our custom LP module is optional to use by integrators so don't have to be forcefully included in the deployment configs.