### PR TITLE
feat: add support to pass gamma directly

### DIFF
--- a/packages/doppler-v4-sdk/src/entities/factory/ReadWriteFactory.ts
+++ b/packages/doppler-v4-sdk/src/entities/factory/ReadWriteFactory.ts
@@ -186,13 +186,15 @@ export class ReadWriteFactory extends ReadFactory {
       params.tickSpacing
     );
 
-    const gamma = this.computeOptimalGamma(
-      startTick,
-      endTick,
-      params.duration,
-      params.epochLength,
-      params.tickSpacing
-    );
+    const gamma =
+      params.gamma ??
+      this.computeOptimalGamma(
+        startTick,
+        endTick,
+        params.duration,
+        params.epochLength,
+        params.tickSpacing
+      );
 
     const startTime = params.blockTimestamp + 30;
     const endTime = params.blockTimestamp + params.duration * DAY_SECONDS + 30;

--- a/packages/doppler-v4-sdk/src/types.ts
+++ b/packages/doppler-v4-sdk/src/types.ts
@@ -91,6 +91,7 @@ export interface DopplerPreDeploymentConfig {
   numeraire?: Address; // defaults to native if unset
   priceRange: PriceRange;
   tickSpacing: number;
+  gamma?: number; // allow gamma to be passed directly instead of computed
   fee: number; // In bips
 
   // Sale parameters


### PR DESCRIPTION
This is a simple PR to add support for optionally passing gamma directly to the `DopplerPreDeploymentConfig` other than using the computed one from `computeOptimalGamma`.