### PR TITLE
fix: remove initialPrice from doppler params

### DIFF
--- a/packages/doppler-v4-sdk/src/entities/factory/ReadWriteFactory.ts
+++ b/packages/doppler-v4-sdk/src/entities/factory/ReadWriteFactory.ts
@@ -228,12 +228,7 @@ export class ReadWriteFactory extends ReadFactory {
       tokenURI: params.tokenURI,
     };
 
-    const initialPrice = BigInt(
-      TickMath.getSqrtRatioAtTick(startTick).toString()
-    );
-
     const dopplerParams: DopplerData = {
-      initialPrice,
       minimumProceeds: params.minProceeds,
       maximumProceeds: params.maxProceeds,
       startingTime: BigInt(startTime),
@@ -319,7 +314,6 @@ export class ReadWriteFactory extends ReadFactory {
       params.numeraire !== '0x0000000000000000000000000000000000000000';
 
     const {
-      initialPrice,
       minimumProceeds,
       maximumProceeds,
       startingTime,
@@ -335,7 +329,6 @@ export class ReadWriteFactory extends ReadFactory {
 
     const poolInitializerData = encodeAbiParameters(
       [
-        { type: 'uint160' },
         { type: 'uint256' },
         { type: 'uint256' },
         { type: 'uint256' },
@@ -350,7 +343,6 @@ export class ReadWriteFactory extends ReadFactory {
         { type: 'int24' },
       ],
       [
-        initialPrice,
         minimumProceeds,
         maximumProceeds,
         startingTime,

--- a/packages/doppler-v4-sdk/src/entities/factory/types/miner.ts
+++ b/packages/doppler-v4-sdk/src/entities/factory/types/miner.ts
@@ -1,7 +1,6 @@
 import { Address } from 'viem';
 
 export interface DopplerData {
-  initialPrice: bigint;
   minimumProceeds: bigint;
   maximumProceeds: bigint;
   startingTime: bigint;

--- a/packages/doppler-v4-sdk/src/entities/factory/utils/airlockMiner.ts
+++ b/packages/doppler-v4-sdk/src/entities/factory/utils/airlockMiner.ts
@@ -52,7 +52,6 @@ export function mine(params: MineV4Params): [Hash, Address, Address, Hex, Hex] {
     params.numeraire !== '0x0000000000000000000000000000000000000000';
 
   const {
-    initialPrice,
     minimumProceeds,
     maximumProceeds,
     startingTime,
@@ -68,7 +67,6 @@ export function mine(params: MineV4Params): [Hash, Address, Address, Hex, Hex] {
 
   const poolInitializerData = encodeAbiParameters(
     [
-      { type: 'uint160' },
       { type: 'uint256' },
       { type: 'uint256' },
       { type: 'uint256' },
@@ -83,7 +81,6 @@ export function mine(params: MineV4Params): [Hash, Address, Address, Hex, Hex] {
       { type: 'int24' },
     ],
     [
-      initialPrice,
       minimumProceeds,
       maximumProceeds,
       startingTime,

--- a/packages/doppler-v4-sdk/src/entities/factory/utils/configBuilder.ts
+++ b/packages/doppler-v4-sdk/src/entities/factory/utils/configBuilder.ts
@@ -74,12 +74,7 @@ export function buildConfig(
     tokenURI: params.tokenURI,
   };
 
-  const initialPrice = BigInt(
-    TickMath.getSqrtRatioAtTick(startTick).toString()
-  );
-
   const dopplerParams: DopplerData = {
-    initialPrice,
     minimumProceeds: params.minProceeds,
     maximumProceeds: params.maxProceeds,
     startingTime: BigInt(startTime),


### PR DESCRIPTION
Remove `initialPrice` from being encoded with other doppler params for `poolInitializerData` as it's not a param needed to pass to doppler hook deployment, as per the contract code [here](https://github.com/whetstoneresearch/doppler/blob/main/src/UniswapV4Initializer.sol#L38).