### PR TITLE
Improve search logic

### DIFF
--- a/packages/doppler-v3-indexer/src/api/index.ts
+++ b/packages/doppler-v3-indexer/src/api/index.ts
@@ -33,11 +33,7 @@ app.get("/search/:query", async (c) => {
       .where(
         and(
           inArray(token.chainId, chainIds || []),
-          or(
-            ilike(token.name, `%${query}%`),
-            ilike(token.symbol, `%${query}%`),
-            ilike(token.address, `%${query}%`)
-          )
+          or(ilike(token.name, `%${query}%`), ilike(token.symbol, `%${query}%`))
         )
       )
       .orderBy(desc(token.holderCount))

--- a/packages/doppler-v3-indexer/src/api/index.ts
+++ b/packages/doppler-v3-indexer/src/api/index.ts
@@ -6,6 +6,7 @@ import {
   graphql,
   ilike,
   inArray,
+  like,
   or,
   replaceBigInts,
 } from "ponder";
@@ -31,9 +32,18 @@ app.get("/search/:query", async (c) => {
       .select()
       .from(token)
       .where(
-        and(
-          inArray(token.chainId, chainIds || []),
-          or(ilike(token.name, `%${query}%`), ilike(token.symbol, `%${query}%`))
+        or(
+          and(
+            inArray(token.chainId, chainIds || []),
+            or(
+              ilike(token.name, `%${query}%`),
+              ilike(token.symbol, `%${query}%`)
+            )
+          ),
+          and(
+            inArray(token.chainId, chainIds || []),
+            like(token.address, query)
+          )
         )
       )
       .orderBy(desc(token.holderCount))


### PR DESCRIPTION
Previous Behavior:
User sends search query and gets all tokens with name, symbol, or address containing their query.

This produced poor UX when searching for single-letter tokens because any token with an address that contained the searched letter would be returned.

New Behavior:
Search for tokens with name or symbol containing the search query. If a token's address exactly matches the search query, return the token.
