### PR TITLE
fix: update repository URL in package.json

### DIFF
--- a/packages/doppler-router/package.json
+++ b/packages/doppler-router/package.json
@@ -22,11 +22,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/whetstone-research/doppler-router.git"
+    "url": "https://github.com/whetstoneresearch/doppler-sdk.git"
   },
-  "homepage": "https://github.com/whetstone-research/doppler-router",
+  "homepage": "https://github.com/whetstoneresearch/doppler-sdk",
   "bugs": {
-    "url": "https://github.com/whetstone-research/doppler-router/issues"
+    "url": "https://github.com/whetstoneresearch/doppler-sdk/issues"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/doppler-v3-sdk/package.json
+++ b/packages/doppler-v3-sdk/package.json
@@ -24,11 +24,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/whetstone-research/doppler-v3-sdk.git"
+    "url": "https://github.com/whetstoneresearch/doppler-sdk.git"
   },
-  "homepage": "https://github.com/whetstone-research/doppler-v3-sdk",
+  "homepage": "https://github.com/whetstoneresearch/doppler-sdk",
   "bugs": {
-    "url": "https://github.com/whetstone-research/doppler-v3-sdk/issues"
+    "url": "https://github.com/whetstoneresearch/doppler-sdk/issues"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
otherwise the link at  https://npmjs.com/package/doppler-v3-sdk is incorrect